### PR TITLE
Implement merge request creation functionality

### DIFF
--- a/src/handlers/repository-handlers.ts
+++ b/src/handlers/repository-handlers.ts
@@ -170,15 +170,59 @@ export const updateMergeRequest: ToolHandler = async (params, context) => {
   if (!project_id || !merge_request_iid) {
     throw new McpError(ErrorCode.InvalidParams, 'project_id and merge_request_iid are required');
   }
-  
+
   if (!title && !description) {
     throw new McpError(ErrorCode.InvalidParams, 'At least one of title or description is required');
   }
-  
+
   const response = await context.axiosInstance.put(
     `/projects/${encodeURIComponent(String(project_id))}/merge_requests/${merge_request_iid}`,
     { title, description }
   );
+  return formatResponse(response.data);
+};
+
+/**
+ * Create merge request handler
+ */
+export const createMergeRequest: ToolHandler = async (params, context) => {
+  const {
+    project_id,
+    source_branch,
+    target_branch,
+    title,
+    description,
+    assignee_id,
+    labels,
+    remove_source_branch,
+    squash
+  } = params.arguments || {};
+
+  if (!project_id || !source_branch || !target_branch || !title) {
+    throw new McpError(
+      ErrorCode.InvalidParams,
+      'project_id, source_branch, target_branch, and title are required'
+    );
+  }
+
+  const requestBody: any = {
+    source_branch,
+    target_branch,
+    title
+  };
+
+  // Add optional parameters if provided
+  if (description !== undefined) requestBody.description = description;
+  if (assignee_id !== undefined) requestBody.assignee_id = assignee_id;
+  if (labels !== undefined) requestBody.labels = labels;
+  if (remove_source_branch !== undefined) requestBody.remove_source_branch = remove_source_branch;
+  if (squash !== undefined) requestBody.squash = squash;
+
+  const response = await context.axiosInstance.post(
+    `/projects/${encodeURIComponent(String(project_id))}/merge_requests`,
+    requestBody
+  );
+
   return formatResponse(response.data);
 };
 

--- a/src/utils/tool-registry.ts
+++ b/src/utils/tool-registry.ts
@@ -30,6 +30,7 @@ export const toolRegistry: ToolRegistry = {
   gitlab_create_merge_request_note: repoHandlers.createMergeRequestNote,
   gitlab_create_merge_request_note_internal: repoHandlers.createMergeRequestNoteInternal,
   gitlab_update_merge_request: repoHandlers.updateMergeRequest,
+  gitlab_create_merge_request: repoHandlers.createMergeRequest,
   gitlab_list_issues: repoHandlers.listIssues,
   gitlab_get_repository_file: repoHandlers.getRepositoryFile,
   gitlab_compare_branches: repoHandlers.compareBranches,

--- a/src/utils/tools-data.ts
+++ b/src/utils/tools-data.ts
@@ -196,6 +196,52 @@ export const toolDefinitions = [
     }
   },
   {
+    name: 'gitlab_create_merge_request',
+    description: 'Create a new merge request in a GitLab project',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        project_id: {
+          type: 'string',
+          description: 'The ID or URL-encoded path of the project'
+        },
+        source_branch: {
+          type: 'string',
+          description: 'The source branch name'
+        },
+        target_branch: {
+          type: 'string',
+          description: 'The target branch name'
+        },
+        title: {
+          type: 'string',
+          description: 'The title of the merge request'
+        },
+        description: {
+          type: 'string',
+          description: 'The description of the merge request'
+        },
+        assignee_id: {
+          type: 'number',
+          description: 'The ID of the user to assign the merge request to'
+        },
+        labels: {
+          type: 'string',
+          description: 'Comma-separated list of labels'
+        },
+        remove_source_branch: {
+          type: 'boolean',
+          description: 'Whether to remove the source branch after merge'
+        },
+        squash: {
+          type: 'boolean',
+          description: 'Whether to squash commits when merging'
+        }
+      },
+      required: ['project_id', 'source_branch', 'target_branch', 'title']
+    }
+  },
+  {
     name: 'gitlab_list_issues',
     description: 'List issues in a GitLab project',
     inputSchema: {


### PR DESCRIPTION
I've successfully create MR with Claude Code:
```
● Perfect! Merge request successfully created. Here are the details:

Merge Request Created:
- Title: Add comprehensive README for sample project
- MR ID: !1
- Source Branch: test-mcp-mr
- Target Branch: master
- Status: Opened
- URL: https://GITLAB_URL/USER/REPO/-/merge_requests/1
- Remove Source Branch: Enabled (will remove branch after merge)
```