### PR TITLE
feat: add inline comment support for merge requests

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -112,6 +112,38 @@ Update a merge request title and description
 | `title` | `string` | No | The title of the merge request |
 | `description` | `string` | No | The description of the merge request |
 
+### gitlab_create_merge_request_discussion
+
+Create an inline comment/discussion on a specific line in a merge request. This is the full-featured version that requires commit SHAs.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+| ---- | ---- | -------- | ----------- |
+| `project_id` | `string` | No | The ID or URL-encoded path of the project |
+| `merge_request_iid` | `number` | No | The internal ID of the merge request |
+| `body` | `string` | No | The content of the comment |
+| `position` | `object` | No | Position information for the inline comment |
+| `start_sha` | `string` | Yes | SHA of the start commit (where the MR starts) |
+| `head_sha` | `string` | Yes | SHA of the head commit (latest commit in the MR) |
+| `new_path` | `string` | Yes | Path to the file in the new version |
+| `old_path` | `string` | Yes | Path to the file in the old version (same as new_path if not renamed) |
+
+### gitlab_create_merge_request_discussion_simple
+
+Create an inline comment on a specific line in a merge request (simplified version). Automatically fetches commit SHAs from the merge request.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+| ---- | ---- | -------- | ----------- |
+| `project_id` | `string` | Yes | The ID or URL-encoded path of the project |
+| `merge_request_iid` | `number` | Yes | The internal ID of the merge request |
+| `body` | `string` | Yes | The content of the comment |
+| `file_path` | `string` | Yes | Path to the file to comment on |
+| `line_number` | `number` | Yes | Line number to comment on |
+| `line_type` | `string` | Yes | Type of line:  |
+
 ### gitlab_list_issues
 
 List issues in a GitLab project

--- a/src/types/repository.types.ts
+++ b/src/types/repository.types.ts
@@ -1,0 +1,25 @@
+/**
+ * Type definitions for GitLab repository operations
+ */
+
+/**
+ * Position object for inline comments in merge request discussions
+ */
+export interface DiscussionPosition {
+  base_sha: string;
+  start_sha: string;
+  head_sha: string;
+  new_path: string;
+  old_path: string;
+  new_line?: number | null;
+  old_line?: number | null;
+}
+
+/**
+ * Diff refs from merge request for creating discussions
+ */
+export interface DiffRefs {
+  base_sha: string;
+  start_sha: string;
+  head_sha: string;
+}

--- a/src/utils/tool-registry.ts
+++ b/src/utils/tool-registry.ts
@@ -30,6 +30,8 @@ export const toolRegistry: ToolRegistry = {
   gitlab_create_merge_request_note: repoHandlers.createMergeRequestNote,
   gitlab_create_merge_request_note_internal: repoHandlers.createMergeRequestNoteInternal,
   gitlab_update_merge_request: repoHandlers.updateMergeRequest,
+  gitlab_create_merge_request_discussion: repoHandlers.createMergeRequestDiscussion,
+  gitlab_create_merge_request_discussion_simple: repoHandlers.createMergeRequestDiscussionSimple,
   gitlab_list_issues: repoHandlers.listIssues,
   gitlab_get_repository_file: repoHandlers.getRepositoryFile,
   gitlab_compare_branches: repoHandlers.compareBranches,
@@ -68,4 +70,4 @@ export const toolRegistry: ToolRegistry = {
   gitlab_add_group_member: usersGroupsHandlers.addGroupMember,
   gitlab_list_project_members: usersGroupsHandlers.listProjectMembers,
   gitlab_add_project_member: usersGroupsHandlers.addProjectMember
-}; 
+};

--- a/src/utils/tools-data.ts
+++ b/src/utils/tools-data.ts
@@ -196,6 +196,98 @@ export const toolDefinitions = [
     }
   },
   {
+    name: 'gitlab_create_merge_request_discussion',
+    description: 'Create an inline comment/discussion on a specific line in a merge request. This is the full-featured version that requires commit SHAs.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        project_id: {
+          type: 'string',
+          description: 'The ID or URL-encoded path of the project'
+        },
+        merge_request_iid: {
+          type: 'number',
+          description: 'The internal ID of the merge request'
+        },
+        body: {
+          type: 'string',
+          description: 'The content of the comment'
+        },
+        position: {
+          type: 'object',
+          description: 'Position information for the inline comment',
+          properties: {
+            base_sha: {
+              type: 'string',
+              description: 'SHA of the base commit (parent of the MR)'
+            },
+            start_sha: {
+              type: 'string',
+              description: 'SHA of the start commit (where the MR starts)'
+            },
+            head_sha: {
+              type: 'string',
+              description: 'SHA of the head commit (latest commit in the MR)'
+            },
+            new_path: {
+              type: 'string',
+              description: 'Path to the file in the new version'
+            },
+            old_path: {
+              type: 'string',
+              description: 'Path to the file in the old version (same as new_path if not renamed)'
+            },
+            new_line: {
+              type: ['number', 'null'],
+              description: 'Line number in the new version (null if line was removed)'
+            },
+            old_line: {
+              type: ['number', 'null'],
+              description: 'Line number in the old version (null if line was added)'
+            }
+          },
+          required: ['base_sha', 'start_sha', 'head_sha', 'new_path', 'old_path']
+        }
+      },
+      required: ['project_id', 'merge_request_iid', 'body', 'position']
+    }
+  },
+  {
+    name: 'gitlab_create_merge_request_discussion_simple',
+    description: 'Create an inline comment on a specific line in a merge request (simplified version). Automatically fetches commit SHAs from the merge request.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        project_id: {
+          type: 'string',
+          description: 'The ID or URL-encoded path of the project'
+        },
+        merge_request_iid: {
+          type: 'number',
+          description: 'The internal ID of the merge request'
+        },
+        body: {
+          type: 'string',
+          description: 'The content of the comment'
+        },
+        file_path: {
+          type: 'string',
+          description: 'Path to the file to comment on'
+        },
+        line_number: {
+          type: 'number',
+          description: 'Line number to comment on'
+        },
+        line_type: {
+          type: 'string',
+          description: 'Type of line: "new" for added/modified lines, "old" for removed lines',
+          enum: ['new', 'old']
+        }
+      },
+      required: ['project_id', 'merge_request_iid', 'body', 'file_path', 'line_number', 'line_type']
+    }
+  },
+  {
     name: 'gitlab_list_issues',
     description: 'List issues in a GitLab project',
     inputSchema: {
@@ -857,4 +949,4 @@ export const toolDefinitions = [
 export const repositoryTools = toolDefinitions.slice(0, 12);
 export const integrationTools = toolDefinitions.slice(10, 20);
 export const cicdTools = toolDefinitions.slice(20, 31);
-export const usersGroupsTools = toolDefinitions.slice(31); 
+export const usersGroupsTools = toolDefinitions.slice(31);


### PR DESCRIPTION
Add support for creating inline/line-level comments on merge request diffs using GitLab's Discussions API. This enables AI assistants to provide precise, line-specific code review feedback similar to human reviewers.

## What's Added

### New Tools
- `gitlab_create_merge_request_discussion`: Full-featured tool for creating
  inline comments with manual commit SHA specification
- `gitlab_create_merge_request_discussion_simple`: Simplified tool that
  automatically fetches commit SHAs from the merge request

### Implementation Details
- Created `src/types/repository.types.ts` with proper TypeScript interfaces
  for discussion positions and diff references
- Added handlers in `src/handlers/repository-handlers.ts` using GitLab's
  Discussions API endpoint
- Registered tools in tool registry
- Auto-generated documentation in TOOLS.md

## Usage Example

The simplified version makes it easy to add inline comments:
```json
{
  "project_id": "my-project",
  "merge_request_iid": 42,
  "body": "Consider using async/await here for better readability",
  "file_path": "src/server.ts",
  "line_number": 45,
  "line_type": "new"
}